### PR TITLE
XR Feature: confirmation email should include term/year + all instructors

### DIFF
--- a/server/src/controllers/courseController.js
+++ b/server/src/controllers/courseController.js
@@ -132,8 +132,19 @@ export const register = async (req, res) => {
   });
 
   const userEmail = updateAccount.email;
-  const subject = "Successfully registered for " + course.title;
+  const subject =
+    "Successfully registered for " +
+    course.title +
+    "(" +
+    course.semester +
+    " " +
+    course.calendarYear +
+    ")!";
+  const donotreply = "--- Do not reply to this email ---";
   const emailBody =
+    donotreply +
+    "\n\n" +
+    "Dear " +
     updateAccount.firstName +
     " " +
     updateAccount.lastName +
@@ -151,7 +162,10 @@ export const register = async (req, res) => {
     "See you in class!" +
     "\n\n" +
     "Your instructors, \n" +
-    instructors;
+    instructors +
+    "\n\n" +
+    donotreply;
+
   let emailReq = {
     email: userEmail,
     subject: subject,


### PR DESCRIPTION
**Fixes Issue #424** (to be tested since I'm having trouble connecting to the server)

_Milestones:_
* Added semester and year in the confirmation email. 
* Refactored instructor signatures such that if there are multiple instructors, all of their names are included in the notification email (I iterated through the course.instructors array and formatted all instructors into a string that gets returned). @madooei let me know if you'd prefer the signature to just be "Hourly Team".  