### PR TITLE
Fixed Calendar event preview appearing after not creating an event

### DIFF
--- a/client/src/pages/calendar/Calendar.jsx
+++ b/client/src/pages/calendar/Calendar.jsx
@@ -142,7 +142,7 @@ function Calendar() {
               selectable={isStaff ? true : false}
               selectAllow={handleSelectAllow}
               selectMirror={isStaff ? true : false}
-              unselectAuto={false}
+              unselectAuto={true}
               events={Array.isArray(data?.calendar) ? data?.calendar: []}
               select={handleSelect}
               slotDuration="0:30:00"


### PR DESCRIPTION
Changed unselectAuto attribute of FullCalendar from true to false to get event preview to disappear. Appears that FullCalendar made changes to their code that we use which caused this recent issue.