### PR TITLE
Fix for issue #473: Error with date displayed on notification with cancelled recurring office hours

### DIFF
--- a/client/src/pages/calendar/register/RegisterForm.jsx
+++ b/client/src/pages/calendar/register/RegisterForm.jsx
@@ -90,8 +90,6 @@ function RegisterForm() {
   const end = useStoreEvent((state) => state.end);
   const id = useStoreEvent((state) => state.id);
 
-  console.log(start);
-
   const date = start.toDateString();
   const startTime = DateTime.fromJSDate(start).toLocaleString(
     DateTime.TIME_SIMPLE


### PR DESCRIPTION
Fixes issue #473 by pulling the date for a cancelled office hour from the event if it is a recurring event, rather than from the date from the first recurring event.


Recurring event created
<img width="298" alt="Screenshot 2023-04-15 at 3 23 14 PM" src="https://user-images.githubusercontent.com/72629007/232249514-a8515d35-8f2d-4632-a8cc-ecf64b11b1d4.png">


Here is the event to be deleted; with current dev, toast noti after deleting would have 4/16
<img width="558" alt="Screenshot 2023-04-15 at 3 23 30 PM" src="https://user-images.githubusercontent.com/72629007/232249535-fc52fbf5-42af-4d0c-bd04-93f150fd6a63.png">

Now deleting event displays correct date
<img width="554" alt="Screenshot 2023-04-15 at 3 24 40 PM" src="https://user-images.githubusercontent.com/72629007/232249592-2dac526e-c9ec-4232-a60c-0c18681833a6.png">


Singleton events also are deleted with the proper date on the notification
<img width="299" alt="Screenshot 2023-04-15 at 3 25 01 PM" src="https://user-images.githubusercontent.com/72629007/232249599-1532621f-cdfe-4c7e-8b9b-2607b27c3aa9.png">

<img width="554" alt="Screenshot 2023-04-15 at 3 25 16 PM" src="https://user-images.githubusercontent.com/72629007/232249613-1e8fc392-fa83-4b69-8526-a24a5850a72c.png">