### PR TITLE
Fixed registration constraint middleware to apply to start of booking…

### DIFF
--- a/server/src/controllers/officeHourController.js
+++ b/server/src/controllers/officeHourController.js
@@ -630,7 +630,7 @@ export const getTimeSlotsRemaining = async (req, res) => {
       const beforeConstraint = new Date(justDate);
       beforeConstraint.setUTCMinutes(sessionStartTime.getUTCMinutes());
       beforeConstraint.setUTCHours(
-        beforeConstraint.getUTCHours() - course.startRegConstraint
+        sessionStartTime.getUTCHours() - course.startRegConstraint
       );
       const endConstraint = new Date(justDate);
       endConstraint.setUTCDate(
@@ -638,7 +638,7 @@ export const getTimeSlotsRemaining = async (req, res) => {
       );
       endConstraint.setUTCMinutes(sessionStartTime.getUTCMinutes());
       endConstraint.setUTCHours(
-        endConstraint.getUTCHours() - course.endRegConstraint
+        sessionStartTime.getUTCHours() - course.endRegConstraint
       );
       if (
         available &&

--- a/server/src/util/courseValidator.js
+++ b/server/src/util/courseValidator.js
@@ -784,8 +784,10 @@ export const isWithinRegisterConstraint = async (req, res, next) => {
     },
   });
   const currDate = new Date();
-  const dateObj = handleUTCDateChange(new Date(date), officeHour);
-  dateObj.setUTCMinutes(new Date(officeHour.startDate).getUTCMinutes());
+  const dateObj = new Date(date);
+  const timeObj = stringToTimeObj(startTime);
+  dateObj.setUTCHours(timeObj.getUTCHours());
+  dateObj.setUTCMinutes(timeObj.getUTCMinutes());
   const before = new Date(dateObj);
   const end = new Date(dateObj);
   before.setUTCHours(before.getUTCHours() - course.startRegConstraint);

--- a/server/src/util/officeHourValidator.js
+++ b/server/src/util/officeHourValidator.js
@@ -817,10 +817,9 @@ export const isRegistrationInFutureByIdParams = async (req, res, next) => {
   });
   debug("got registration");
   const startTimeObj = new Date(registration.startTime);
-  const dateObj = handleUTCDateChange(
-    new Date(registration.date),
-    registration.officeHour
-  );
+  const dateObj = new Date(registration.date);
+  dateObj.setUTCHours(startTimeObj.getUTCHours());
+  dateObj.setUTCMinutes(startTimeObj.getUTCMinutes());
   if (dateObj > new Date()) {
     debug("registration is in future");
     next();
@@ -843,7 +842,9 @@ export const isRegistrationInFuture = async (req, res, next) => {
   });
   debug("got office hour");
   const startTimeObj = stringToTimeObj(startTime);
-  const dateObj = handleUTCDateChange(new Date(date), officeHour);
+  const dateObj = new Date(date);
+  dateObj.setUTCHours(startTimeObj.getUTCHours());
+  dateObj.setUTCMinutes(startTimeObj.getUTCMinutes());
   if (dateObj > new Date()) {
     debug("registration is in future");
     next();


### PR DESCRIPTION
…, not session

This fixes so bookings are limited by session time, not the start of an office hour