### PR TITLE
Fixed issue with calendar being clipped after sidebar open/close

### DIFF
--- a/client/src/pages/calendar/Calendar.jsx
+++ b/client/src/pages/calendar/Calendar.jsx
@@ -44,6 +44,7 @@ function Calendar() {
   const setAnchorEl = useStoreLayout((state) => state.setEventAnchorEl);
   const mobileCalMenu = useStoreLayout((state) => state.mobileCalMenu);
   const setMobileCalMenu = useStoreLayout((state) => state.setMobileCalMenu);
+  const openSidebar = useStoreLayout((state) => state.openSidebar);
 
   const token = useStoreToken((state) => state.token);
   const { id } = decodeToken(token);
@@ -58,6 +59,10 @@ function Calendar() {
   useEffect(() => {
     setIsStaff(courseType === "Staff" || courseType === "Instructor");
   }, [courseType]);
+
+  useEffect(() => {
+      setTimeout(() => calendarRef.current.getApi().updateSize(), 500);
+  }, [openSidebar]);
 
   const handleEventClick = (info) => {
     matchUpSm ? setAnchorEl(info.el) : NiceModal.show("mobile-event-popup");


### PR DESCRIPTION
When the sidebar opens/closes the calendar adjusts properly to the new width:
![image](https://user-images.githubusercontent.com/89753540/236637873-d7957d82-9c27-4c76-b672-2d28b957df30.png)
![image](https://user-images.githubusercontent.com/89753540/236637882-399cb51b-8422-4f71-bdea-0f17404ccaad.png)

Previous view:
![image](https://user-images.githubusercontent.com/89753540/236637927-af098700-7c49-4128-9776-12b67e992a04.png)
![image](https://user-images.githubusercontent.com/89753540/236637939-70e206d7-6cfb-4434-86dc-8aa297e3d10e.png)
