### PR TITLE
fixed hour-off bug for Toast notif after registration

### DIFF
--- a/client/src/hooks/useMutationCancelRegistration.jsx
+++ b/client/src/hooks/useMutationCancelRegistration.jsx
@@ -41,6 +41,7 @@ function useMutationCancelRegistration(registrationId) {
       const startTime = DateTime.fromISO(registration.startTime).toLocaleString(
         DateTime.TIME_SIMPLE
       );
+
       const endTime = DateTime.fromISO(registration.endTime).toLocaleString(
         DateTime.TIME_SIMPLE
       );


### PR DESCRIPTION
Resolving issue where Toast notification after registration would be an hour off. (Issue #492)
<img width="828" alt="Screenshot 2023-05-06 at 3 33 04 PM" src="https://user-images.githubusercontent.com/72629007/236643346-52c9b8bb-6651-42a5-b54f-867910c132c9.png">
<img width="831" alt="Screenshot 2023-05-06 at 3 33 16 PM" src="https://user-images.githubusercontent.com/72629007/236643347-37213f5d-0cf8-4b83-afca-cc9f48ef87ac.png">

Like how Chris did with the backend to look at time offsets, I changed it so that during registration we now consider the time offset between the current date's timezone and what is stored for the registration (which is 1970-01-01 UTC time). If the offsets are different, it replaces the 1970-01-01 with the current date before calling toLocaleString, thus resulting in the proper time for the current time zone and DST situation.