### PR TITLE
Fixes error that is thrown by non-SSO login 

### DIFF
--- a/client/src/pages/authentication/AuthLogin.jsx
+++ b/client/src/pages/authentication/AuthLogin.jsx
@@ -37,8 +37,7 @@ function AuthLogin() {
     signIn(data);
   };
 
-
-  const handleClickShowPassword = () => setShowPassword((show) => !show);
+  const handleClickShowPassword = () => setShowPassword((showPassword) => !showPassword);
 
   const handleMouseDownPassword = (event) => {
     event.preventDefault();


### PR DESCRIPTION
Resolves issue #551 

Moved useState hook higher up so it is always invoked. There was a return statement that was triggering above it, causing the error. Now, logging in as a non SSO user no longer throws the error and properly directs to the courses page.

Current error
https://user-images.githubusercontent.com/72629007/236644916-7934f8af-32e4-4b60-80d5-a44322df460c.mov

Fixed
https://user-images.githubusercontent.com/72629007/236644923-f72c85c5-f28b-4062-9c78-8b46817636ea.mov

