### PR TITLE
Editing Recurring Office Hour

### DIFF
--- a/client/src/pages/calendar/upsert-event/EditEventForm.jsx
+++ b/client/src/pages/calendar/upsert-event/EditEventForm.jsx
@@ -11,6 +11,10 @@ import { DateTime } from "luxon";
 import FormCheckbox from "../../../components/form-ui/FormCheckbox";
 import useMutationEditEvent from "../../../hooks/useMutationEditEvent";
 import useStoreEvent from "../../../hooks/useStoreEvent";
+import { useState } from "react";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
 
 const BUTTONS = [
   {
@@ -56,9 +60,11 @@ const BUTTONS = [
  */
 function EditEventForm() {
   const start = useStoreEvent((state) => state.start);
+  const oldEndDate = useStoreEvent((state) => state.start);
   const end = useStoreEvent((state) => state.end);
   const location = useStoreEvent((state) => state.location);
   const recurring = useStoreEvent((state) => state.recurring);
+  const [editType, setEditType] = useState("all");
 
   const { control, handleSubmit, watch } = useForm({
     defaultValues: {
@@ -101,7 +107,7 @@ function EditEventForm() {
           endDate: end.toISOString(),
           location: data.location,
           daysOfWeek: data.days,
-          endDateOldOfficeHour: DateTime.fromJSDate(start, {
+          endDateOldOfficeHour: DateTime.fromJSDate((editType === "all" ? oldEndDate : start), {
             zone: "utc",
           }).toFormat("MM-dd-yyyy"),
           editAfterDate: true,
@@ -139,6 +145,25 @@ function EditEventForm() {
               control={control}
               label="Recurring event"
             />
+          )}
+          {recurringEvent && (
+            <RadioGroup
+              value={editType}
+              onChange={(event) => setEditType(event.target.value)}
+            >
+              <Stack direction="row" sx={{ width: "100%" }} spacing={1}>
+              <FormControlLabel
+                value="all"
+                control={<Radio />}
+                label="This event and future events"
+              />
+              <FormControlLabel
+                value="futureOnly"
+                control={<Radio />}
+                label="Future events only"
+              />
+              </Stack>
+            </RadioGroup>
           )}
           <FormInputText
             name="startDate"


### PR DESCRIPTION
When editing a recurring office hour, the user now has the option whether to include the current event, or only edit future events. This fixes a bug where when a recurring office hour is moved to recur on a day later in the week, it doesn't delete the original office hour that was edited.

Editing both current & future events:
![image](https://github.com/jhu-collab/proj-hourly/assets/89753540/35b285a5-17fa-4bbe-b9fd-2597776d79d3)
![image](https://github.com/jhu-collab/proj-hourly/assets/89753540/828445e9-cfcd-4c5e-add2-56d7ff8c7040)
![image](https://github.com/jhu-collab/proj-hourly/assets/89753540/c88bfc94-85df-49dc-a9fe-4aea899c4333)

Editing only future events:
![image](https://github.com/jhu-collab/proj-hourly/assets/89753540/35b285a5-17fa-4bbe-b9fd-2597776d79d3)
![image](https://github.com/jhu-collab/proj-hourly/assets/89753540/1022b771-3815-4337-b4e5-a57b6836016f)
![image](https://github.com/jhu-collab/proj-hourly/assets/89753540/285e7568-88fa-4084-925e-2c7f8eeccefb)
